### PR TITLE
feat: change settings button color to red

### DIFF
--- a/style.css
+++ b/style.css
@@ -57,13 +57,13 @@ html::-webkit-scrollbar {
 
 .settings-button {
   padding: 8px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, #dc2626 0%, #b91c1c 100%);
   border: none;
   border-radius: 12px;
   color: white;
   cursor: pointer;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
+  box-shadow: 0 2px 8px rgba(220, 38, 38, 0.3);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -74,7 +74,7 @@ html::-webkit-scrollbar {
 
 .settings-button:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(102, 126, 234, 0.4);
+  box-shadow: 0 8px 24px rgba(220, 38, 38, 0.4);
 }
 
 .settings-button:active {


### PR DESCRIPTION
## Summary
- Changed settings button background gradient from blue/purple to red (#dc2626 to #b91c1c)
- Updated box-shadow colors to match red theme for both normal and hover states
- Maintains consistent visual style and accessibility standards

## Changes Made
- Modified `.settings-button` background gradient in `style.css`
- Updated `.settings-button:hover` box-shadow color to match red theme
- All changes preserve existing button dimensions and interactions

## Test Plan
- [x] Verified CSS changes are correctly applied
- [x] Ensured hover effects work properly with new red color scheme
- [x] Confirmed button maintains proper contrast and accessibility

## Related Issue
Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)