### PR TITLE
Handle gemini limits

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "AI Translator",
     "description": "Translate text using Google Gemini",
-    "version": "2.1",
+    "version": "2.2",
     "icons": {
         "32": "assets/favicon32.png",
         "48": "assets/favicon48.png",

--- a/popup.html
+++ b/popup.html
@@ -1,106 +1,110 @@
 <!DOCTYPE html>
 <html lang="vi">
-  <head>
-    <meta charset="UTF-8" />
-    <title>Gemini Translator</title>
-    <link rel="stylesheet" href="css/tailwind-minimal.css" />
-    <link rel="stylesheet" href="fonts/inter.css" />
-    <link rel="stylesheet" href="fonts/noto-emoji.css" />
-    <link rel="stylesheet" href="style.css" />
-  </head>
-  <body class="modern-bg">
-    <div class="container">
 
-      <!-- Language Selection -->
-      <div class="language-selector">
-        <div class="select-container">
-          <select id="source-lang" class="modern-select">
-            <option value="">🌐 Phát hiện ngôn ngữ</option>
-            <option value="en">🇺🇸 English</option>
-            <option value="vi">🇻🇳 Tiếng Việt</option>
-            <option value="ja">🇯🇵 日本語</option>
-            <option value="zh">🇨🇳 中文</option>
-            <option value="ko">🇰🇷 한국어</option>
-          </select>
-        </div>
-        
-        <button id="switch-lang" class="switch-button">
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/>
-          </svg>
-        </button>
-        
-        <div class="select-container">
-          <select id="target-lang" class="modern-select">
-            <option value="vi">🇻🇳 Tiếng Việt</option>
-            <option value="en">🇺🇸 English</option>
-            <option value="ja">🇯🇵 日本語</option>
-            <option value="zh">🇨🇳 中文</option>
-            <option value="ko">🇰🇷 한국어</option>
-          </select>
-        </div>
+<head>
+  <meta charset="UTF-8" />
+  <title>Gemini Translator</title>
+  <link rel="stylesheet" href="css/tailwind-minimal.css" />
+  <link rel="stylesheet" href="fonts/inter.css" />
+  <link rel="stylesheet" href="fonts/noto-emoji.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+
+<body class="modern-bg">
+  <div class="container">
+
+    <!-- Language Selection -->
+    <div class="language-selector">
+      <div class="select-container">
+        <select id="source-lang" class="modern-select">
+          <option value="">🌐 Phát hiện ngôn ngữ</option>
+          <option value="en">🇺🇸 English</option>
+          <option value="vi">🇻🇳 Tiếng Việt</option>
+          <option value="ja">🇯🇵 日本語</option>
+          <option value="zh">🇨🇳 中文</option>
+          <option value="ko">🇰🇷 한국어</option>
+        </select>
       </div>
 
-      <!-- Input Section -->
-      <div class="input-section">
-        <div class="section-header">
-          <label for="input-text" class="section-label">
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
-            </svg>
-            Nhập văn bản cần dịch
-          </label>
-          
-          <button id="settings-button" class="settings-button" title="Mở cài đặt">
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
-            </svg>
-          </button>
-        </div>
-        <div class="textarea-container">
-          <textarea
-            id="input-text"
-            rows="4"
-            class="modern-textarea input-textarea"
-            placeholder="Nhập hoặc dán văn bản tại đây..."
-            autofocus
-          ></textarea>
-        </div>
-      </div>
+      <button id="switch-lang" class="switch-button">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+        </svg>
+      </button>
 
-      <!-- Output Section -->
-      <div class="output-section">
-        <div class="section-header">
-          <label for="output-text" class="section-label">
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
-            </svg>
-            Kết quả dịch
-          </label>
-          <button id="copy-button" class="copy-button" title="Sao chép kết quả">
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
-            </svg>
-          </button>
-        </div>
-        <div class="textarea-container relative">
-          <textarea
-            id="output-text"
-            rows="4"
-            class="modern-textarea output-textarea"
-            placeholder="Kết quả dịch sẽ hiển thị tại đây..."
-          ></textarea>
-          <div class="copied-notification" id="copied-label">
-            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
-            </svg>
-            Đã sao chép!
-          </div>
-        </div>
+      <div class="select-container">
+        <select id="target-lang" class="modern-select">
+          <option value="vi">🇻🇳 Tiếng Việt</option>
+          <option value="en">🇺🇸 English</option>
+          <option value="ja">🇯🇵 日本語</option>
+          <option value="zh">🇨🇳 中文</option>
+          <option value="ko">🇰🇷 한국어</option>
+        </select>
       </div>
     </div>
 
-    <script type="module" src="popup.js"></script>
-  </body>
+    <!-- Input Section -->
+    <div class="input-section">
+      <div class="section-header">
+        <label for="input-text" class="section-label">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+          </svg>
+          Nhập văn bản cần dịch
+        </label>
+
+        <button id="settings-button" class="settings-button" title="Mở cài đặt">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+        </button>
+      </div>
+      <div class="textarea-container">
+        <textarea id="input-text" rows="4" class="modern-textarea input-textarea"
+          placeholder="Nhập hoặc dán văn bản tại đây..." autofocus></textarea>
+      </div>
+    </div>
+
+    <!-- Output Section -->
+    <div class="output-section">
+      <div class="section-header">
+        <label for="output-text" class="section-label">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          Kết quả dịch
+        </label>
+        <a id="check-quota-link" href="https://aistudio.google.com/rate-limit" target="_blank" class="quota-link hidden"
+          title="Xem hạn mức sử dụng">
+          Kiểm tra
+        </a>
+        <button id="copy-button" class="copy-button" title="Sao chép kết quả">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+          </svg>
+        </button>
+      </div>
+      <div class="textarea-container relative">
+        <textarea id="output-text" rows="4" class="modern-textarea output-textarea"
+          placeholder="Kết quả dịch sẽ hiển thị tại đây..."></textarea>
+        <div class="copied-notification" id="copied-label">
+          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          Đã sao chép!
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="popup.js"></script>
+</body>
+
 </html>

--- a/popup.js
+++ b/popup.js
@@ -9,6 +9,7 @@ document.addEventListener("DOMContentLoaded", function () {
   const copyButton = document.getElementById("copy-button");
   const copiedLabel = document.getElementById("copied-label");
   const settingsButton = document.getElementById("settings-button");
+  const checkQuotaLink = document.getElementById("check-quota-link");
 
   let timeoutId;
   let translationDelay = 500; // default delay - matches settings default
@@ -19,7 +20,7 @@ document.addEventListener("DOMContentLoaded", function () {
   inputTextArea.addEventListener("input", () => {
     clearTimeout(timeoutId);
     const timeout = inputTextArea.value.trim() === '' ? 0 : translationDelay;
-    
+
     timeoutId = setTimeout(() => {
       saveInputText();
       translateText();
@@ -30,6 +31,11 @@ document.addEventListener("DOMContentLoaded", function () {
     chrome.storage.local.set({
       inputText: inputTextArea.value
     });
+  }
+
+  function setOutput(text) {
+    outputTextArea.value = text;
+    saveOutputText();
   }
 
   function saveOutputText() {
@@ -50,26 +56,26 @@ document.addEventListener("DOMContentLoaded", function () {
       translationDelay: 1000
     }, (syncResult) => {
       translationDelay = syncResult.translationDelay;
-      
+
       chrome.storage.local.get(['inputText', 'outputText', 'sourceLang', 'targetLang', 'selectedText', 'fromInPageTranslation'], (result) => {
         // Check if this is from in-page translation
         if (result.fromInPageTranslation && result.selectedText) {
           // Auto-fill with selected text
           inputTextArea.value = result.selectedText;
-          
+
           // Set source language to auto-detect
           sourceLangSelect.value = '';
           targetLangSelect.value = result.targetLang !== undefined ? result.targetLang : 'vi';
-          
+
           // Save the new settings
           saveInputText();
           saveLanguageSettings();
-          
+
           // Auto-translate
           setTimeout(() => {
             translateText();
           }, 100);
-          
+
           // Clear the in-page translation flags
           chrome.storage.local.remove(['selectedText', 'fromInPageTranslation']);
         } else {
@@ -81,11 +87,11 @@ document.addEventListener("DOMContentLoaded", function () {
             outputTextArea.value = result.outputText;
             autoResizeTextarea();
           }
-          
+
           sourceLangSelect.value = result.sourceLang !== undefined ? result.sourceLang : '';
           targetLangSelect.value = result.targetLang !== undefined ? result.targetLang : 'vi';
         }
-        
+
         inputTextArea.focus();
         if (inputTextArea.value) {
           inputTextArea.select();
@@ -124,7 +130,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const apiKeyResult = await new Promise((resolve) => {
       chrome.storage.sync.get(['apiKey'], resolve);
     });
-    
+
     return apiKeyResult.apiKey ? apiKeyResult.apiKey.trim() : '';
   }
 
@@ -134,25 +140,25 @@ document.addEventListener("DOMContentLoaded", function () {
     const text = inputTextArea.value.trim();
 
     if (!text) {
-      outputTextArea.value = "";
-      saveOutputText();
+      setOutput("");
       return;
     }
 
     const maxLength = 8000;
     if (text.length > maxLength) {
-      outputTextArea.value = `❌ Văn bản quá dài!\n\nĐộ dài hiện tại: ${text.length} ký tự\nGiới hạn tối đa: ${maxLength} ký tự`;
-      saveOutputText();
+      setOutput(`❌ Văn bản quá dài!\n\nĐộ dài hiện tại: ${text.length} ký tự\nGiới hạn tối đa: ${maxLength} ký tự`);
       return;
     }
 
     const apiKey = await getApiKey();
 
     if (!apiKey) {
-      outputTextArea.value = "❌ Chưa cài đặt API Key!\n\nVui lòng nhấn vào nút cài đặt và làm theo hướng dẫn";
-      saveOutputText();
+      setOutput("❌ Chưa cài đặt API Key!\n\nVui lòng nhấn vào nút cài đặt và làm theo hướng dẫn");
       return;
     }
+
+    // Hide quota link when starting new translation
+    toggleQuotaLink(false);
 
     try {
       const outputContainer = document.querySelector(".output-section .textarea-container");
@@ -168,45 +174,69 @@ document.addEventListener("DOMContentLoaded", function () {
         throw new Error("Network response was not ok");
       }
 
-      outputTextArea.value = response;
-      saveOutputText();
+      setOutput(response);
 
       autoResizeTextarea();
       scrollToBottom();
     } catch (error) {
       console.error("Error:", error);
-      if (error.message.includes('API_KEY')) {
-        outputTextArea.value = "❌ API Key không hợp lệ!\n\nVui lòng kiểm tra lại API Key trong phần Cài đặt.";
-        saveOutputText();
-      } else if (error.message.includes('503') && error.message.includes('The service is currently unavailable')) {
-        // Retry logic for 503 errors
-        if (retryCount < 2) {
-          outputTextArea.value = "⌛ Máy chủ Google hiện đang bận! Đang thử lại...";
-          saveOutputText();
-          
-          // Wait 1 second then retry
-          setTimeout(() => {
-            translateText(retryCount + 1);
-          }, 1000);
-          return; // Don't remove loading class yet
-        } else {
-          outputTextArea.value = "❌ Máy chủ Google hiện đang bận! Vui lòng thử lại sau.";
-          saveOutputText();
-        }
-      } else {
-        outputTextArea.value = "❌ Lỗi khi dịch!\n\nVui lòng thử lại hoặc kiểm tra kết nối mạng.";
-        saveOutputText();
-      }
+      handleGeminiError(error, retryCount);
     } finally {
       const outputContainer = document.querySelector(".output-section .textarea-container");
       outputContainer.classList.remove("rainbow-loading");
     }
   }
 
+  function toggleQuotaLink(show) {
+    if (typeof checkQuotaLink !== 'undefined' && checkQuotaLink) {
+      if (show) {
+        checkQuotaLink.classList.remove('hidden');
+      } else {
+        checkQuotaLink.classList.add('hidden');
+      }
+    }
+  }
+
+  function handleGeminiError(error, retryCount) {
+    const errorMessage = error.message || '';
+
+    if (errorMessage.includes('API_KEY')) {
+      setOutput("❌ API Key không hợp lệ!\n\nVui lòng kiểm tra lại API Key trong phần Cài đặt.");
+      return;
+    }
+
+    // Check for Rate Limits (429)
+    if (errorMessage.includes('429') || errorMessage.includes('Quota exceeded')) {
+      // Show "Check Quota" link
+      toggleQuotaLink(true);
+
+      setOutput("⚠️ Quá giới hạn sử dụng!\n\nVui lòng kiểm tra hạn mức sử dụng (nút Kiểm tra bên trên) hoặc thử lại sau.");
+      return;
+    }
+
+    // Check for Server Errors (503)
+    if (errorMessage.includes('503') || errorMessage.includes('The service is currently unavailable')) {
+      if (retryCount < 2) {
+        setOutput("⌛ Máy chủ Google hiện đang bận! Đang thử lại...");
+
+        setTimeout(() => {
+          translateText(retryCount + 1);
+        }, 1000);
+        return;
+      } else {
+        setOutput("❌ Máy chủ Google hiện đang bận! Vui lòng thử lại sau.");
+        return;
+      }
+    }
+
+    // Generic Errors
+    setOutput(`❌ Lỗi khi dịch: ${errorMessage}\n\nVui lòng thử lại hoặc kiểm tra kết nối mạng.`);
+  }
+
   switchLangButton.addEventListener("click", () => {
     // prevent multiple event calls
     isSwitching = true;
-    
+
     const sourceLang = sourceLangSelect.value;
     sourceLangSelect.value = targetLangSelect.value;
 
@@ -215,7 +245,7 @@ document.addEventListener("DOMContentLoaded", function () {
     } else {
       targetLangSelect.value = targetLangSelect.value === 'vi' ? 'en' : 'vi';
     }
-    
+
     saveLanguageSettings();
 
     isSwitching = false;
@@ -231,14 +261,14 @@ document.addEventListener("DOMContentLoaded", function () {
     if (!outputText.trim()) {
       return;
     }
-    
+
     try {
       await navigator.clipboard.writeText(outputText);
 
       // Copied animation
       copiedLabel.classList.add("show");
       copiedLabel.classList.remove("hidden");
-      setTimeout(function(){
+      setTimeout(function () {
         copiedLabel.classList.remove("show");
         copiedLabel.classList.add("hidden");
       }, 2000);
@@ -256,9 +286,8 @@ function getPrompt({ text, sourceLang, targetLang }) {
   sourceLang = convertLanguage(sourceLang);
   targetLang = convertLanguage(targetLang);
 
-  let prompt = `- Yêu cầu: Dịch đoạn sau${
-    sourceLang ? " từ " + sourceLang : ""
-  } sang ${targetLang}
+  let prompt = `- Yêu cầu: Dịch đoạn sau${sourceLang ? " từ " + sourceLang : ""
+    } sang ${targetLang}
 - Lưu ý: `;
 
   prompt += `Chỉ trả về bản dịch, không kèm thông tin gì khác. `;
@@ -274,7 +303,7 @@ function getPrompt({ text, sourceLang, targetLang }) {
 function convertLanguage(language) {
   let output = "";
 
-  switch(language) {
+  switch (language) {
     case "en":
       output = "tiếng Anh";
       break;
@@ -307,7 +336,7 @@ async function translateByGemini(prompt, apiKey) {
     const genAI = new GoogleGenerativeAI(apiKey);
 
     // The Gemini 2.5-flash-lite models are versatile and work with most use cases
-    const model = genAI.getGenerativeModel({ 
+    const model = genAI.getGenerativeModel({
       model: "gemini-2.5-flash-lite",
       generationConfig: {
         temperature: 0.2,
@@ -338,9 +367,9 @@ function scrollToBottom() {
   // Scroll the container to bring the output section into view
   const outputSection = document.querySelector('.output-section');
   if (outputSection) {
-    outputSection.scrollIntoView({ 
-      behavior: 'smooth', 
-      block: 'end' 
+    outputSection.scrollIntoView({
+      behavior: 'smooth',
+      block: 'end'
     });
   }
 }

--- a/style.css
+++ b/style.css
@@ -702,3 +702,22 @@ input:checked + .toggle-slider:before {
   font-weight: 500;
   cursor: pointer;
 }
+
+/* Quota Link */
+.quota-link {
+  font-size: 0.875rem;
+  color: #3b82f6; /* Blue-500 */
+  text-decoration: none;
+  margin-right: 0.75rem;
+  font-weight: 500;
+  transition: color 0.2s;
+}
+
+.quota-link:hover {
+  text-decoration: underline;
+  color: #2563eb; /* Blue-600 */
+}
+
+.quota-link.hidden {
+  display: none;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes translation error-handling paths (including retries) and adds new UI behavior for rate-limit scenarios, which could affect user-facing translation flow if error detection misfires.
> 
> **Overview**
> Improves the popup’s handling of Gemini failures by centralizing output updates (`setOutput`) and routing errors through `handleGeminiError`, with clearer messaging and preserved 503 retry behavior.
> 
> Adds explicit rate-limit (429/quota exceeded) handling that reveals a new **“Kiểm tra”** link to Google AI Studio’s quota page, plus supporting `.quota-link` styling, and bumps the extension version to `2.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04458a34085eeb36d0f541106372a6fb359930db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->